### PR TITLE
InspectorControls changed to wp.components

### DIFF
--- a/src/block/block.js
+++ b/src/block/block.js
@@ -21,7 +21,7 @@ const {
 	} = wp.blocks; // Import registerBlockType() from wp.blocks
 
 //this is where block control componants go! a-ha!
-const { ToggleControl, SelectControl } = InspectorControls;
+const { ToggleControl, SelectControl } = wp.components;
 /**
  * Register: aa Gutenberg Block.
  *


### PR DESCRIPTION
Your registerBlockType "Teaser" Block can't display , cause you wrote InspectorControls 24 line in block.js " const { ToggleControl, SelectControl } = InspectorControls; "  so it can't display register block.  you need to change your code " const { ToggleControl, SelectControl } = wp.components ".  